### PR TITLE
[Home] Fix undefined in search if type is not address

### DIFF
--- a/app/assets/javascripts/administrate/places.js.erb
+++ b/app/assets/javascripts/administrate/places.js.erb
@@ -4,7 +4,7 @@ places({
   countries: ['FR'],
   templates: {
     value: function(suggestion) {
-      return suggestion.name + ', ' + suggestion.postcode + ' ' + suggestion.city ;
+      return [suggestion.name, suggestion.postcode, suggestion.city].filter(Boolean).join(" ");
     },
   },
   container: document.querySelector('.places-js-container')

--- a/app/javascript/packs/components/places-input.js.erb
+++ b/app/javascript/packs/components/places-input.js.erb
@@ -12,7 +12,7 @@ class PlacesInput {
         countries: ['FR'],
         templates: {
           value: function(suggestion) {
-            return suggestion.name + ', ' + suggestion.postcode + ' ' + suggestion.city ;
+            return [suggestion.name, suggestion.postcode, suggestion.city].filter(Boolean).join(" ");
           },
         },
         container: container


### PR DESCRIPTION
Comme on accepte autre chose que les suggestions de type adresse, certaines valeurs sont parfois undefined, ce changement fait sauter la virgule mais permet d'afficher simplement et correctement tous les types de suggestion.
![image](https://user-images.githubusercontent.com/847942/69970269-3f189800-151e-11ea-9d51-b742fb07816b.png)
